### PR TITLE
Reduce requirement for R

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,3 +1,4 @@
+^appveyor\.yml$
 ^\.travis\.yml$
 ^.dict.rds
 ^examples

--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,3 +1,4 @@
+^\.travis\.yml$
 ^.dict.rds
 ^examples
 ^src/.*\.o

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,7 @@ r:
 - 3.2
 - 3.3
 - 3.4
-- release
-- devel
+
+os: 
+  - linux
+  - osx 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@
 
 language: R
 cache: packages
-
+warnings_are_errors: true
 r:
 - 3.2
 - 3.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ language: R
 cache: packages
 warnings_are_errors: true
 r:
-- 3.3
+- 3.3.0
 - 3.4
 - 3.5
 - devel

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ os:
 before_install: 
   - if [[ "${TRAVIS_OS_NAME}" = 'osx' ]]; 
     then 
+      sudo chown -R $(whoami) /usr/local/share/man/man7 ;
       brew update;
       brew install -v libgit2; 
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ warnings_are_errors: true
 r:
 - 3.3
 - 3.4
+- 3.5
+- devel
 osx_image: xcode9 
 
 os: 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,15 @@ warnings_are_errors: true
 r:
 - 3.3
 - 3.4
+osx_image: xcode9 
 
 os: 
   - linux
   - osx 
+
+before_install: 
+  - if [[ "${TRAVIS_OS_NAME}" = 'osx' ]]; 
+    then 
+      brew update;
+      brew install -v libgit2; 
+    fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+# R for travis: see documentation at https://docs.travis-ci.com/user/languages/r
+
+language: R
+cache: packages
+
+r:
+- 3.2
+- 3.3
+- 3.4
+- release
+- devel

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ language: R
 cache: packages
 warnings_are_errors: true
 r:
-- 3.2
 - 3.3
 - 3.4
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,7 +10,7 @@ Authors@R: c(person("Olaf", "Mersmann", role=c("aut", "cre"),
              person("Björn", "Bornkamp", role=c("aut")))
 URL: https://github.com/olafmersmann/truncnorm
 BugReports: https://github.com/olafmersmann/truncnorm/issues
-Depends: R (>= 3.2)
+Depends: R (>= 3.3.3)
 Suggests: testthat
 License: GPL (>= 2)
 Encoding: UTF-8

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,7 +10,7 @@ Authors@R: c(person("Olaf", "Mersmann", role=c("aut", "cre"),
              person("Björn", "Bornkamp", role=c("aut")))
 URL: https://github.com/olafmersmann/truncnorm
 BugReports: https://github.com/olafmersmann/truncnorm/issues
-Depends: R (>= 3.3.3)
+Depends: R (>= 3.3)
 Suggests: testthat
 License: GPL (>= 2)
 Encoding: UTF-8

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,7 +10,7 @@ Authors@R: c(person("Olaf", "Mersmann", role=c("aut", "cre"),
              person("Björn", "Bornkamp", role=c("aut")))
 URL: https://github.com/olafmersmann/truncnorm
 BugReports: https://github.com/olafmersmann/truncnorm/issues
-Depends: R (>= 3.2.0)
+Depends: R (>= 3.3.3)
 Suggests: testthat
 License: GPL (>= 2)
 Encoding: UTF-8

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,7 +10,7 @@ Authors@R: c(person("Olaf", "Mersmann", role=c("aut", "cre"),
              person("Björn", "Bornkamp", role=c("aut")))
 URL: https://github.com/olafmersmann/truncnorm
 BugReports: https://github.com/olafmersmann/truncnorm/issues
-Depends: R (>= 3.4.0)
+Depends: R (>= 3.2.0)
 Suggests: testthat
 License: GPL (>= 2)
 Encoding: UTF-8

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,7 +10,7 @@ Authors@R: c(person("Olaf", "Mersmann", role=c("aut", "cre"),
              person("Björn", "Bornkamp", role=c("aut")))
 URL: https://github.com/olafmersmann/truncnorm
 BugReports: https://github.com/olafmersmann/truncnorm/issues
-Depends: R (>= 3.3.3)
+Depends: R (>= 3.2)
 Suggests: testthat
 License: GPL (>= 2)
 Encoding: UTF-8

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,10 +27,6 @@ environment:
       CRAN: http://cran.rstudio.com
       R_VER: 3.3
 
-    - R_VERSION: 3.2.5
-      CRAN: http://cran.rstudio.com
-      R_VER: 3.2      
-
 
 # Adapt as necessary starting from here
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,14 +18,13 @@ environment:
     USE_RTOOLS: true
     R_CHECK_INSTALL_ARGS: "--install-args=--build --no-multiarch "
     WARNINGS_ARE_ERRORS: 1
+    CRAN: http://cran.rstudio.com    
   matrix:
+    - R_VERSION: release
+    - R_VERSION: devel
     - R_VERSION: oldrel
-      CRAN: http://cran.rstudio.com
-      R_VER: 3.4
-
-    - R_VERSION: 3.3.0
-      CRAN: http://cran.rstudio.com
-      R_VER: 3.3
+    - R_VERSION: 3.3.3
+      
 
 
 # Adapt as necessary starting from here

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,7 +23,7 @@ environment:
     - R_VERSION: release
     - R_VERSION: devel
     - R_VERSION: oldrel
-    - R_VERSION: 3.3.3
+    - R_VERSION: 3.3.0
       
 
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,13 +26,9 @@ environment:
       CRAN: http://cran.rstudio.com
       R_VER: 3.4
 
-    - R_VERSION: 3.3.3
+    - R_VERSION: 3.3.0
       CRAN: http://cran.rstudio.com
       R_VER: 3.3
-
-    - R_VERSION: 3.2.5
-      CRAN: http://cran.rstudio.com
-      R_VER: 3.2
 
 
 # Adapt as necessary starting from here

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,67 @@
+# DO NOT CHANGE the "init" and "install" sections below
+
+# Download script file from GitHub
+init:
+  ps: |
+        $ErrorActionPreference = "Stop"
+        Invoke-WebRequest http://raw.github.com/krlmlr/r-appveyor/master/scripts/appveyor-tool.ps1 -OutFile "..\appveyor-tool.ps1"
+        Import-Module '..\appveyor-tool.ps1'
+
+install:
+  ps: Bootstrap
+
+cache:
+  - C:\RLibrary
+
+environment:
+  global:
+    USE_RTOOLS: true
+    R_CHECK_INSTALL_ARGS: "--install-args=--build --no-multiarch "
+    WARNINGS_ARE_ERRORS: 1
+    PYTHON_VERSION: 3.6
+    MINICONDA: C:\Miniconda3-x64
+    R_ARCH: x64
+  matrix:
+    - R_VERSION: oldrel
+      CRAN: http://cran.rstudio.com
+      R_VER: 3.4
+
+    - R_VERSION: 3.3.3
+      CRAN: http://cran.rstudio.com
+      R_VER: 3.3
+
+    - R_VERSION: 3.2.5
+      CRAN: http://cran.rstudio.com
+      R_VER: 3.2
+
+
+# Adapt as necessary starting from here
+
+build_script:
+  - travis-tool.sh install_deps
+
+test_script:
+  - travis-tool.sh run_tests
+
+on_failure:
+  - 7z a failure.zip *.Rcheck\*
+  - appveyor PushArtifact failure.zip
+
+artifacts:
+  - path: '*.Rcheck\**\*.log'
+    name: Logs
+
+  - path: '*.Rcheck\**\*.out'
+    name: Logs
+
+  - path: '*.Rcheck\**\*.fail'
+    name: Logs
+
+  - path: '*.Rcheck\**\*.Rout'
+    name: Logs
+
+  - path: '\*_*.tar.gz'
+    name: Bits
+
+  - path: '\*_*.zip'
+    name: Bits

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,9 +18,6 @@ environment:
     USE_RTOOLS: true
     R_CHECK_INSTALL_ARGS: "--install-args=--build --no-multiarch "
     WARNINGS_ARE_ERRORS: 1
-    PYTHON_VERSION: 3.6
-    MINICONDA: C:\Miniconda3-x64
-    R_ARCH: x64
   matrix:
     - R_VERSION: oldrel
       CRAN: http://cran.rstudio.com
@@ -29,6 +26,10 @@ environment:
     - R_VERSION: 3.3.0
       CRAN: http://cran.rstudio.com
       R_VER: 3.3
+
+    - R_VERSION: 3.2.5
+      CRAN: http://cran.rstudio.com
+      R_VER: 3.2      
 
 
 # Adapt as necessary starting from here


### PR DESCRIPTION
It looks like truncnorm `R (>= 3.4.0)` requirement is overly stringent https://travis-ci.com/muschellij2/truncnorm (Linux and OSX) and https://ci.appveyor.com/project/muschellij2/truncnorm (checking on Windows).  This can be checked on Travis and Appveyor.  

Fixes #1 